### PR TITLE
justify: true を設定

### DIFF
--- a/template/utils.typ
+++ b/template/utils.typ
@@ -76,6 +76,7 @@
   set par(
     leading: 1.1em,
     spacing: 1.1em,
+    justify: true,
     linebreaks: auto,
     first-line-indent: (
       amount: 1em,


### PR DESCRIPTION
右端で揃っていなかったのキモすぎた。普通に忘れていました。

`par` に `justify: true` を設定しました。