### PR TITLE
PRコメントの改善・artifactのアップロードのオプションの修正

### DIFF
--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -93,7 +93,7 @@ jobs:
           cd "${{ github.workspace }}/${{ matrix.dir }}"
           make compile
 
-          # ファルパスから "articles/" を削除し、"/" を "_" に置換
+          # ファイルパスから "articles/" を削除し、"/" を "_" に置換
           ARTIFACT_NAME=$(echo "${{ matrix.dir }}" | sed 's|^articles/||' | tr '/' '_')
           mv main.pdf "${ARTIFACT_NAME}.pdf"
 
@@ -150,7 +150,7 @@ jobs:
             pdf_size=$(numfmt --to=iec --suffix=B <<< "$pdf_size_bytes")
             pdf_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${pdf_id}"
 
-            echo "| ${article_name} | [プラウザで見る](${preview_url}) (${zip_size}) | [PDFをダウンロード](${pdf_url}) (${pdf_size}) |" >> comment.md
+            echo "| ${article_name} | [ブラウザで見る](${preview_url}) (${zip_size}) | [PDFをダウンロード](${pdf_url}) (${pdf_size}) |" >> comment.md
           done
 
           # 4. 共通フッターの追加

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -139,7 +139,6 @@ jobs:
             article_name="${zip_name%.pdf.zip}"
             
             zip_size=$(numfmt --to=iec --suffix=B <<< "$zip_size_bytes")
-            zip_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${zip_id}"
             preview_url="https://word-coins.github.io/artifact-previewer/?owner=${owner}&repo=${repo}&artifact_id=${zip_id}"
 
             # 対応する .pdf アーティファクトを検索
@@ -150,8 +149,8 @@ jobs:
             pdf_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${pdf_id}"
 
             echo "- ${article_name}" >> comment.md
-            echo "  - [${article_name}.pdf](${pdf_url}) (${pdf_size})" >> comment.md
-            echo "  - [${zip_name}](${zip_url}) (${zip_size}): [プレビュー](${preview_url})" >> comment.md
+            echo "  - [ZIP圧縮されたPDFファイルをブラウザで開く](${preview_url}): (${zip_size})" >> comment.md
+            echo "  - [ArtifactのPDFファイルを表示](${pdf_url}): (${pdf_size})" >> comment.md
           done
 
           # 4. 共通フッターの追加

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -107,6 +107,14 @@ jobs:
           path: ${{ github.workspace }}/${{ matrix.dir }}/${{ steps.compile_article.outputs.artifact_name }}.pdf
           retention-days: 7
 
+      - name: upload artifact(uncompressed)
+        id: upload_artifact_uncompressed
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.compile_article.outputs.artifact_name }}.pdf
+          path: ${{ github.workspace }}/${{ matrix.dir }}/${{ steps.compile_article.outputs.artifact_name }}.pdf
+          retention-days: 7
+
   comment-artifact:
     needs: compile-articles
     runs-on: ubuntu-24.04
@@ -120,16 +128,28 @@ jobs:
           echo "## :tada:記事がビルドされました！:tada:" > comment.md
           echo "" >> comment.md
 
-          # jqで各ArtifactのnameとIDを抽出してループ
-          echo "$ARTIFACTS_JSON" | jq -r '.artifacts[] | "\(.name)\t\(.id)"' | while IFS=$'\t' read -r name id; do
-            # 'owner/repo' を/で区切りownerとrepoを取得
-            owner=$(echo "${{ github.repository }}" | cut -d'/' -f1)
-            repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          # 'owner/repo' を/で区切りownerとrepoを取得
+          owner=$(echo "${{ github.repository }}" | cut -d'/' -f1)
+          repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+
+          # .pdf.zipアーティファクトを基準に記事名でグループ化して出力
+          echo "$ARTIFACTS_JSON" | jq -r '.artifacts[] | select(.name | endswith(".pdf.zip")) | "\(.name)\t\(.id)\t\(.size_in_bytes)"' | while IFS=$'\t' read -r zip_name zip_id zip_size_bytes; do
+            article_name="${zip_name%.pdf.zip}"
             
-            artifact_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${id}"
-            preview_url="https://word-coins.github.io/artifact-previewer/?owner=${owner}&repo=${repo}&artifact_id=${id}"
-            
-            echo "- [${name}](${artifact_url}) ([プレビュー](${preview_url}))" >> comment.md
+            zip_size=$(numfmt --to=iec --suffix=B <<< "$zip_size_bytes")
+            zip_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${zip_id}"
+            preview_url="https://word-coins.github.io/artifact-previewer/?owner=${owner}&repo=${repo}&artifact_id=${zip_id}"
+
+            # 対応する .pdf アーティファクトを検索
+            pdf_info=$(echo "$ARTIFACTS_JSON" | jq -r --arg pdfname "${article_name}.pdf" '.artifacts[] | select(.name == $pdfname) | "\(.id)\t\(.size_in_bytes)"')
+            pdf_id=$(echo "$pdf_info" | cut -f1)
+            pdf_size_bytes=$(echo "$pdf_info" | cut -f2)
+            pdf_size=$(numfmt --to=iec --suffix=B <<< "$pdf_size_bytes")
+            pdf_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${pdf_id}"
+
+            echo "- ${article_name}" >> comment.md
+            echo "  - [${article_name}.pdf](${pdf_url}) (${pdf_size})" >> comment.md
+            echo "  - [${zip_name}](${zip_url}) (${zip_size}): [プレビュー](${preview_url})" >> comment.md
           done
 
           # 4. 共通フッターの追加

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -114,6 +114,7 @@ jobs:
           name: ${{ steps.compile_article.outputs.artifact_name }}.pdf
           path: ${{ github.workspace }}/${{ matrix.dir }}/${{ steps.compile_article.outputs.artifact_name }}.pdf
           retention-days: 7
+          archive: false
 
   comment-artifact:
     needs: compile-articles

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -106,6 +106,7 @@ jobs:
           name: ${{ steps.compile_article.outputs.artifact_name }}.pdf.zip
           path: ${{ github.workspace }}/${{ matrix.dir }}/${{ steps.compile_article.outputs.artifact_name }}.pdf
           retention-days: 7
+          compression-level: 9
 
       - name: upload artifact(uncompressed)
         id: upload_artifact_uncompressed

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -18,7 +18,7 @@ jobs:
           commits: ${{ github.event.pull_request.commits }}
 
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ steps.get_fetch_depth.outputs.fetch_depth }}
@@ -41,7 +41,7 @@ jobs:
         dir: ${{ fromJson(needs.get-branch-info.outputs.dirs) }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Prepare Variables
         run: |
           if [ "$(uname -m)" = "x86_64" ]; then
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Cache Typst
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: typst-cache
         with:
           path: /usr/local/bin/typst
@@ -74,7 +74,7 @@ jobs:
           rm typst.tar.xz
 
       - name: Cache Fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: fonts-cache
         with:
           path: |

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -129,6 +129,8 @@ jobs:
           
           echo "## :tada:記事がビルドされました！:tada:" > comment.md
           echo "" >> comment.md
+          echo "| 記事名 | プレビュー (推奨) | ダウンロード (予備) |" >> comment.md
+          echo "| :--- | :--- | :--- |" >> comment.md
 
           # 'owner/repo' を/で区切りownerとrepoを取得
           owner=$(echo "${{ github.repository }}" | cut -d'/' -f1)
@@ -148,9 +150,7 @@ jobs:
             pdf_size=$(numfmt --to=iec --suffix=B <<< "$pdf_size_bytes")
             pdf_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${pdf_id}"
 
-            echo "- ${article_name}" >> comment.md
-            echo "  - [ZIP圧縮されたPDFファイルをブラウザで開く](${preview_url}): (${zip_size})" >> comment.md
-            echo "  - [ArtifactのPDFファイルを表示](${pdf_url}): (${pdf_size})" >> comment.md
+            echo "| ${article_name} | [プラウザで見る](${preview_url}) (${zip_size}) | [PDFをダウンロード](${pdf_url}) (${pdf_size}) |" >> comment.md
           done
 
           # 4. 共通フッターの追加

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -156,10 +156,14 @@ jobs:
           # 4. 共通フッターの追加
           job_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           expired_date=$(date --date "7 days" +%F)
+          commit_sha="${{ github.event.pull_request.head.sha }}"
+          commit_link="${{ github.server_url }}/${{ github.repository }}/commit/${commit_sha}"
           
           echo "" >> comment.md
-          echo "有効期限 (おおよそ): ${expired_date}" >> comment.md
-          echo "有効期限が切れた場合は [こちら](${job_url}) から「Re-run all jobs」を実行してください。" >> comment.md
+          echo "**ビルド情報**" >> comment.md
+          echo "- コミット: [\`${commit_sha:0:7}\`](${commit_link})" >> comment.md
+          echo "- 有効期限 (おおよそ): ${expired_date}" >> comment.md
+          echo "- 有効期限が切れた場合は [こちら](${job_url}) から「Re-run all jobs」を実行してください。" >> comment.md
 
           gh pr comment "${{ github.event.pull_request.html_url }}" --body-file comment.md --edit-last --create-if-none
 

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -3,6 +3,7 @@ name: Articles Branch CI
 on:
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 jobs:
   get-branch-info:

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Variables
         run: |
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: Cache Typst
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: typst-cache
         with:
           path: /usr/local/bin/typst
@@ -45,7 +45,7 @@ jobs:
           rm typst.tar.xz
 
       - name: Cache Fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: fonts-cache
         with:
           path: |
@@ -62,7 +62,7 @@ jobs:
         run: make compile
 
       - name: upload 
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: main.pdf
           path: main.pdf

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -66,4 +66,5 @@ jobs:
         with:
           name: main.pdf
           path: main.pdf
-          retention-days: 3
+          retention-days: 7
+          archive: false


### PR DESCRIPTION
Close #40
Close #48
Close #44

- PRコメントの表示形式を改善
- zipにせずアップロードしたリンクを追加
- mainブランチのartifactのオプションを変更
- actionsのバージョン更新（actions/cache@v4→v5、actions/checkout@v4→v6）
- article branchのCIにworkflow_dispatchを追加

例:
https://github.com/oka4shi/article-template-typst/pull/2#issuecomment-4003211724 
<img width="1730" height="762" alt="image" src="https://github.com/user-attachments/assets/5e294130-877c-40ed-accf-f184b517373d" />
